### PR TITLE
docs: make Chinese README the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # uni-app-tailwindcss-template
 
-This repository holds the publishable `pnpm create uni-app-tailwindcss` initializer and its registered templates. Source and releases are hosted at [sonofmagic/uni-app-tailwindcss-template](https://github.com/sonofmagic/uni-app-tailwindcss-template).
+简体中文 | [English](./README_EN.md)
 
-## Packages
+本仓库包含可发布的 `pnpm create uni-app-tailwindcss` 初始化工具及其注册模板。源码和版本发布位于 [sonofmagic/uni-app-tailwindcss-template](https://github.com/sonofmagic/uni-app-tailwindcss-template)。
 
-- `packages/template`: the default uni-app template source used for local development and generation
-- `packages/create-uni-app-tailwindcss`: the CLI that backs `pnpm create uni-app-tailwindcss`
-- `templates.json`: the template registry used by the CLI, root scripts, and CI matrices
+## 包结构
 
-## Usage
+- `packages/template`：用于本地开发和生成项目的默认 uni-app 模板源码
+- `packages/create-uni-app-tailwindcss`：为 `pnpm create uni-app-tailwindcss` 提供支持的 CLI
+- `templates.json`：CLI 打包、根脚本和 CI 矩阵共用的模板注册表
+
+## 本地开发
 
 ```bash
 pnpm install
@@ -18,9 +20,9 @@ pnpm test:smoke
 pnpm test:e2e
 ```
 
-## Template HMR verification
+## 模板 HMR 验收
 
-The root scripts proxy the default template's artifact and runtime HMR checks:
+根脚本会代理默认模板的产物层和真实运行时 HMR 检查：
 
 ```bash
 pnpm test:hmr:artifact:mp-weixin
@@ -31,45 +33,45 @@ pnpm test:hmr:app:ios -- --device-id <ios-simulator-uuid> --hbuilderx-cli <hbuil
 pnpm test:hmr:all
 ```
 
-CI runs the headless artifact check for every registered HMR target. Desktop runtime requirements and evidence details are documented in [`packages/template/README.md`](packages/template/README.md#tailwind-css-hmr-四端验收).
+CI 会为每个已注册的 HMR 目标运行无界面的产物层检查。桌面运行时要求和验收证据说明见 [`packages/template/README.md`](packages/template/README.md#tailwind-css-hmr-四端验收)。
 
-## Create a new project
+## 创建项目
 
 ```bash
 pnpm create uni-app-tailwindcss my-app
 ```
 
-Use `--template <id>` to select a registered template without an interactive prompt:
+在 CI 或其他非交互场景中，可以通过 `--template <id>` 指定已注册的模板：
 
 ```bash
 pnpm create uni-app-tailwindcss my-app --template default
 ```
 
-The command copies the selected bundled template into `my-app`, rewrites the package name, and leaves you with a normal pnpm project.
+该命令会把选中的内置模板复制到 `my-app`，改写包名，并生成一个可独立使用的 pnpm 项目。
 
-## Update dependencies
+## 更新依赖
 
-Use separate commands for regular dependencies and the uni-app compiler toolchain:
+普通依赖和 uni-app 编译工具链使用不同的更新命令：
 
 ```bash
 pnpm update:deps
 pnpm update:uni-app
 ```
 
-`update:deps` interactively updates regular dependencies in the default template while leaving the DCloud-managed uni-app compatibility set unchanged. `update:uni-app` uses the official UVM tool to update that compatibility set together.
+`update:deps` 会交互式更新默认模板的普通依赖，并保留 DCloud 管理的 uni-app 兼容性依赖。`update:uni-app` 使用官方 UVM 工具统一更新这组兼容性依赖。
 
-## Add a template
+## 添加模板
 
-1. Add its source as a workspace package under `packages/`.
-2. Register its id, source, build targets, HMR targets, and H5 smoke text in `templates.json`.
-3. Implement `test:hmr:artifact:<target>` for each registered HMR target.
-4. Run `pnpm create:build` and `pnpm test:e2e`.
+1. 在 `packages/` 下添加模板源码，并将其声明为 workspace 包。
+2. 在 `templates.json` 中注册模板 ID、源码目录、构建目标、HMR 目标和 H5 冒烟文本。
+3. 为每个已注册的 HMR 目标实现 `test:hmr:artifact:<target>`。
+4. 运行 `pnpm create:build` 和 `pnpm test:e2e`。
 
-The create package bundles every registered template. GitHub Actions also derives its build and HMR matrices from the registry, so new templates do not require workflow edits.
+create 包会打包所有已注册的模板。GitHub Actions 也会从注册表生成构建和 HMR 矩阵，因此添加模板时无需修改 workflow。
 
-## Release
+## 发布
 
-Package versions and releases use pnpm native versioning with repoctl:
+包版本和发布流程使用 pnpm 原生版本管理与 repoctl：
 
 ```bash
 pnpm release
@@ -77,4 +79,4 @@ pnpm release:status
 pnpm repo:doctor
 ```
 
-Commit the generated change intent with the user-visible change. The release workflow creates a version PR from pending intents and publishes the merged version to npm with provenance.
+将生成的 change intent 与用户可见变更一同提交。Release workflow 会根据待处理的 intent 创建版本 PR，并在版本 PR 合并后通过 provenance 发布到 npm。

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,0 +1,82 @@
+# uni-app-tailwindcss-template
+
+[简体中文](./README.md) | English
+
+This repository holds the publishable `pnpm create uni-app-tailwindcss` initializer and its registered templates. Source and releases are hosted at [sonofmagic/uni-app-tailwindcss-template](https://github.com/sonofmagic/uni-app-tailwindcss-template).
+
+## Packages
+
+- `packages/template`: the default uni-app template source used for local development and generation
+- `packages/create-uni-app-tailwindcss`: the CLI that backs `pnpm create uni-app-tailwindcss`
+- `templates.json`: the template registry used by the CLI, root scripts, and CI matrices
+
+## Local development
+
+```bash
+pnpm install
+pnpm dev:h5
+pnpm dev:mp-weixin
+pnpm test:smoke
+pnpm test:e2e
+```
+
+## Template HMR verification
+
+The root scripts proxy the default template's artifact and runtime HMR checks:
+
+```bash
+pnpm test:hmr:artifact:mp-weixin
+pnpm test:hmr:h5
+pnpm test:hmr:mp-weixin
+pnpm test:hmr:app:android -- --device-id <android-device-id> --hbuilderx-cli <hbuilderx-cli>
+pnpm test:hmr:app:ios -- --device-id <ios-simulator-uuid> --hbuilderx-cli <hbuilderx-cli>
+pnpm test:hmr:all
+```
+
+CI runs the headless artifact check for every registered HMR target. Desktop runtime requirements and evidence details are documented in [`packages/template/README.md`](packages/template/README.md#tailwind-css-hmr-四端验收).
+
+## Create a new project
+
+```bash
+pnpm create uni-app-tailwindcss my-app
+```
+
+Use `--template <id>` to select a registered template in CI or other non-interactive environments:
+
+```bash
+pnpm create uni-app-tailwindcss my-app --template default
+```
+
+The command copies the selected bundled template into `my-app`, rewrites the package name, and leaves you with a standalone pnpm project.
+
+## Update dependencies
+
+Use separate commands for regular dependencies and the uni-app compiler toolchain:
+
+```bash
+pnpm update:deps
+pnpm update:uni-app
+```
+
+`update:deps` interactively updates regular dependencies in the default template while leaving the DCloud-managed uni-app compatibility set unchanged. `update:uni-app` uses the official UVM tool to update that compatibility set together.
+
+## Add a template
+
+1. Add its source as a workspace package under `packages/`.
+2. Register its ID, source, build targets, HMR targets, and H5 smoke text in `templates.json`.
+3. Implement `test:hmr:artifact:<target>` for each registered HMR target.
+4. Run `pnpm create:build` and `pnpm test:e2e`.
+
+The create package bundles every registered template. GitHub Actions also derives its build and HMR matrices from the registry, so new templates do not require workflow edits.
+
+## Release
+
+Package versions and releases use pnpm native versioning with repoctl:
+
+```bash
+pnpm release
+pnpm release:status
+pnpm repo:doctor
+```
+
+Commit the generated change intent with the user-visible change. The release workflow creates a version PR from pending intents and publishes the merged version to npm with provenance.


### PR DESCRIPTION
## 变更内容

- 将根 `README.md` 调整为默认中文说明
- 新增完整英文版 `README_EN.md`
- 在中英文文档顶部增加双向语言切换
- 保持包结构、HMR 验收、脚手架、依赖升级和 repoctl 发布说明一致

## Release

- 不需要 changeset：仅修改仓库根文档，不影响 npm 包内容或生成模板行为
- 不需要联动 `create-weapp-vite`

## 验证

- `git diff --check`
- 检查中英文文档章节一一对应
- 检查 `README.md` 与 `README_EN.md` 的双向链接